### PR TITLE
メッセージ送信の非同期化実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -33,11 +33,9 @@ $(document).on('turbolinks:load', function() {
       contentType: false
     })
     .done(function(data){
-      console.log(data)
       var html = buildHTML(data);
       $('.mainMessages').append(html);
-      $('.form__message').val('');
-      $('.hidden').val('');
+      $('#new_message')[0].reset();
       $('.mainMessages').animate({ scrollTop: $('.mainMessages')[0].scrollHeight }, 'fast');
     })
     .fail(function(data){

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,50 @@
+$(document).on('turbolinks:load', function() {
+  function buildHTML(message) {
+    var content = message.content ? `${ message.content }` : "";
+    var image = message.image ? `<img src= ${ message.image }>` : "";
+    var html = `<div class="message">
+                  <div class="talkerInfo">
+                    <div class="talkerInfo__userName">
+                      ${ message.user_name }
+                    </div>
+                    <div class="talkerInfo__postedTime">
+                      ${ message.created_at }
+                    </div>
+                  </div>
+                  <div class="lowerMessage">
+                    <p class="lowerMessage__content">
+                      ${ content }
+                    </p>
+                      ${ image }
+                  </div>
+                </div>`
+  return html;
+  }
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var href = window.location.href;
+    $.ajax({
+      url: href,
+      type: 'POST',
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      console.log(data)
+      var html = buildHTML(data);
+      $('.mainMessages').append(html);
+      $('.form__message').val('');
+      $('.hidden').val('');
+      $('.mainMessages').animate({ scrollTop: $('.mainMessages')[0].scrollHeight }, 'fast');
+    })
+    .fail(function(data){
+      alert('Error');
+    })
+    .always(function(data){
+      $('.form__submit').prop('disabled', false);
+    })
+  })
+});

--- a/app/assets/stylesheets/_chatMain.scss
+++ b/app/assets/stylesheets/_chatMain.scss
@@ -44,6 +44,8 @@
     height: calc(100vh - 190px);
     padding: 46px 40px;
     background-color: $main_background;
+    overflow: scroll;
+    width: 100%;
 
     .message {
       .talkerInfo {

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html {redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'}
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -3,7 +3,7 @@
     .talkerInfo__userName
       = message.user.name
     .talkerInfo__postedTime
-      = message.created_at.strftime("%Y/%m%d %H:%M")
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
   .lowerMessage
     - if message.content.present?
       %p.lowerMessage__content

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.id         @message.id
+json.content    @message.content
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.user_name  @message.user.name
+json.image      @message.image.url

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,5 +1,4 @@
 .wrapper
-
   = render 'shared/side_bar'
   
   .chatMain
@@ -20,7 +19,7 @@
 
     .form
       = form_for [@group, @message] do |f|
-        = f.text_field :content, class: 'form__message', placeholder: 'type a message'
+        = f.text_field :content, class: 'form__message', id: 'new__message', placeholder: 'type a message'
         .form__mask
           = f.label :image, class: 'form__mask__image' do
             %i.fa.fa-image


### PR DESCRIPTION
# What
メッセージ送信機能の非同期化を実装する。

# Why
メッセージを送信するたびに送信画面にリダイレクトしているため、ビューが毎回再描画されているため、これに対して非同期化の処理をする。

https://gyazo.com/3b9a2dc433553cf31541969f5e4deef3